### PR TITLE
fix(android): add WebRTC permissions for camera, microphone and screen share

### DIFF
--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -4,10 +4,23 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- WebRTC: voice, video calls and screen share -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <!-- Restart the notification service after a device reboot. -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <!-- Ask to be exempt from battery optimizations so the WS stays connected. -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+
+    <!-- Declare camera/microphone features as optional so the app is still
+         available on devices without them (e.g. tablets/TV). -->
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+    <uses-feature android:name="android.hardware.microphone" android:required="false" />
 
     <application
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Adds CAMERA, RECORD_AUDIO, MODIFY_AUDIO_SETTINGS and Bluetooth permissions needed for Android WebView to request access to the microphone and camera in WebRTC calls.

- Fixes access denied errors when joining voice/video calls.
- Keeps camera and microphone as optional features so the app remains available on devices without them.

Note: screen share on Android requires native MediaProjection support and is not covered by this change.